### PR TITLE
(Android ) Fix missing `sdk-version.json` file in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "android",
     "ios",
     "cpp",
+    "sdk-version.json",
     "RnBugfender.podspec",
     "!lib/typescript/example",
     "!android/build",


### PR DESCRIPTION
### Fixes

sdk-version.json is in the repository but missing from the files allowlist in package.json. Android build was failing with following error

```
Build file '/Users/*/node_modules/@bugfender/rn-bugfender/android/build.gradle' line: 31

A problem occurred evaluating project ':bugfender_rn-bugfender'.
> /Users/*/node_modules/@bugfender/rn-bugfender/android/../sdk-version.json (No such file or directory)
```